### PR TITLE
A few improvements to `LLamaTokenizer` + its unit test

### DIFF
--- a/src/canopy/tokenizer/llama.py
+++ b/src/canopy/tokenizer/llama.py
@@ -31,12 +31,12 @@ class LlamaTokenizer(BaseTokenizer):
         Initialize the tokenizer.
 
         Args:
-            model_name: The name of the model to use. Defaults to "meta-llama/Llama-2-7b-chat-hf".
+            model_name: The name of the model to use. Defaults to "openlm-research/open_llama_7b_v2".
             hf_token: Huggingface token
         """  # noqa: E501
-        hf_token = hf_token or os.environ.get("HUGGINGFACE_TOKEN") 
+        hf_token = hf_token or os.environ.get("HUGGINGFACE_TOKEN")
         #Add legacy=True to avoid extra printings
-        self._encoder = HfTokenizer.from_pretrained(model_name, token=hf_token, legacy=True)
+        self._encoder = HfTokenizer.from_pretrained(model_name, token=hf_token, legacy=True, add_bos_token=False)
 
     def tokenize(self, text: str) -> List[str]:
         """
@@ -48,8 +48,7 @@ class LlamaTokenizer(BaseTokenizer):
         Returns:
             The list of tokens.
         """
-        return [self._encoder.decode([encoded_token])
-                for encoded_token in self._encode(text)]
+        return self._encoder.tokenize(text)
 
     def detokenize(self, tokens: List[str]) -> str:
         """
@@ -61,9 +60,7 @@ class LlamaTokenizer(BaseTokenizer):
         Returns:
             The detokenized text as a string.
         """
-        if not isinstance(tokens, List):
-            raise TypeError(f"detokenize expect List[str], got f{type(tokens)}")
-        return "".join(tokens)
+        return self._encoder.convert_tokens_to_string(tokens)
 
     def token_count(self, text: str) -> int:
         """

--- a/tests/unit/tokenizer/base_test_tokenizer.py
+++ b/tests/unit/tokenizer/base_test_tokenizer.py
@@ -27,8 +27,8 @@ class BaseTestTokenizer(ABC):
     @staticmethod
     def test_tokenize(tokenizer, text, expected_tokens):
         tokens = tokenizer.tokenize(text)
-        assert tokens == expected_tokens
-
+        assert tokens == expected_tokens, f"\nExpected: {expected_tokens}" \
+                                          f"\nActual: {tokens}"
     @staticmethod
     def test_tokenize_empty_string(tokenizer):
         assert tokenizer.tokenize("") == []
@@ -70,6 +70,7 @@ class BaseTestTokenizer(ABC):
     def test_token_count(tokenizer, text, expected_tokens):
         token_count = tokenizer.token_count(text)
         assert token_count == len(expected_tokens)
+        assert token_count == len(tokenizer.tokenize(text))
 
     @staticmethod
     def test_token_count_empty_string(tokenizer):
@@ -79,7 +80,8 @@ class BaseTestTokenizer(ABC):
 
     @staticmethod
     def test_tokenize_detokenize_compatibility(tokenizer, text, expected_tokens):
-        assert tokenizer.detokenize(tokenizer.tokenize(text)) \
-               == text
-        assert tokenizer.tokenize(tokenizer.detokenize(expected_tokens))\
-               == expected_tokens
+        retext = tokenizer.detokenize(tokenizer.tokenize(text))
+        assert retext == text, f"\nExpected: {text}\nActual: {retext}"
+        reconstructed_expected_tokens = tokenizer.tokenize(tokenizer.detokenize(expected_tokens))
+        assert reconstructed_expected_tokens == expected_tokens, \
+            f"\nExpected: {expected_tokens}\nActual: {reconstructed_expected_tokens}"


### PR DESCRIPTION
Namely, the underlying HuggingFace tokenizer has a proper `.tokenize()` method, as well as a `.convert_tokens_to_string()` method which is like `detokenize()`. Together with a few configurations like `add_bos_token=False` - the tokenizer now passes all tests.

(Note: there is an edge case in `test_special_tokens_to_natural_text` which is still failing. I wanna consult with @actav whether \ how this should be fixed. We can merge as-is now and fix in your branch later)